### PR TITLE
Backporting changes from bitcoin

### DIFF
--- a/lib/univalue_utffilter.h
+++ b/lib/univalue_utffilter.h
@@ -13,7 +13,7 @@
 class JSONUTF8StringFilter
 {
 public:
-    JSONUTF8StringFilter(std::string &s):
+    explicit JSONUTF8StringFilter(std::string &s):
         str(s), is_valid(true), codepoint(0), state(0), surpair(0)
     {
     }


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/commit/64fb0ac016c7fd01c60c39af60f6431bac57f9ee

Original comment:

Declare single-argument (non-converting) constructors "explicit"
In order to avoid unintended implicit conversions.