### PR TITLE
Remove unused Homebrew workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ addons:
       - pkg-config
 
 before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew uninstall libtool; brew install libtool; fi
   - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
   - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
 


### PR DESCRIPTION
This reverts 9f0b9975925b202ab130714e5422f8dd8bf40ac3

For context: https://github.com/bitcoin-core/univalue/pull/4#issuecomment-335189936
The workaround was causing issues. Rather than working around those as well,
just revert it altogether.