### PR TITLE
[tests] Fix BOOST_CHECK_THROW macro

### DIFF
--- a/test/object.cpp
+++ b/test/object.cpp
@@ -19,9 +19,10 @@
 #define BOOST_CHECK_THROW(stmt, excMatch) { \
         try { \
             (stmt); \
+            assert(0 && "No exception caught"); \
         } catch (excMatch & e) { \
 	} catch (...) { \
-	    assert(0); \
+	    assert(0 && "Wrong exception caught"); \
 	} \
     }
 #define BOOST_CHECK_NO_THROW(stmt) { \


### PR DESCRIPTION
BOOST_CHECK_THROW doesn't correctly fail the test if no
exception is throw. Fix that (and add an assert message).

Bug and fix found by MarcoFalke.

@MarcoFalke 