### PR TITLE
Remove deprecated std pair wrappers

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -15,7 +15,6 @@
 #include <cassert>
 
 #include <sstream>        // .get_int64()
-#include <utility>        // std::pair
 
 class UniValue {
 public:
@@ -177,75 +176,8 @@ public:
     const UniValue& get_array() const;
 
     enum VType type() const { return getType(); }
-    bool push_back(std::pair<std::string,UniValue> pear) {
-        return pushKV(pear.first, pear.second);
-    }
     friend const UniValue& find_value( const UniValue& obj, const std::string& name);
 };
-
-//
-// The following were added for compatibility with json_spirit.
-// Most duplicate other methods, and should be removed.
-//
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, const char *cVal)
-{
-    std::string key(cKey);
-    UniValue uVal(cVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, std::string strVal)
-{
-    std::string key(cKey);
-    UniValue uVal(strVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, uint64_t u64Val)
-{
-    std::string key(cKey);
-    UniValue uVal(u64Val);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, int64_t i64Val)
-{
-    std::string key(cKey);
-    UniValue uVal(i64Val);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, bool iVal)
-{
-    std::string key(cKey);
-    UniValue uVal(iVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, int iVal)
-{
-    std::string key(cKey);
-    UniValue uVal(iVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, double dVal)
-{
-    std::string key(cKey);
-    UniValue uVal(dVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, const UniValue& uVal)
-{
-    std::string key(cKey);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(std::string key, const UniValue& uVal)
-{
-    return std::make_pair(key, uVal);
-}
 
 enum jtokentype {
     JTOK_ERR        = -1,


### PR DESCRIPTION
These are deprecated and no longer used in Bitcoin Core.