### PR TITLE
Remove UniValue empty dtor to avoid deletion of default move operator/ctor

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -48,7 +48,6 @@ public:
         std::string s(val_);
         setStr(s);
     }
-    ~UniValue() {}
 
     void clear();
 


### PR DESCRIPTION
UniValue is `std::move`'d in a good few places in the code base but it's actually never really moved because the `~UniValue() { }` dtor removes the default move constructors.

I originally declared the default move operations with ` = default` but then that meant I had to add the copy versions too so an extra 4 lines with a useless dtor didn't make much sense :)