### PR TITLE
Define begin() and end() for array types

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -70,6 +70,10 @@ public:
     bool checkObject(const std::map<std::string,UniValue::VType>& memberTypes) const;
     const UniValue& operator[](const std::string& key) const;
     const UniValue& operator[](size_t index) const;
+    std::vector<UniValue>::iterator begin();  // Only defined for array type
+    std::vector<UniValue>::iterator end();  // Only defined for array type
+    std::vector<UniValue>::const_iterator begin() const;  // Only defined for array type
+    std::vector<UniValue>::const_iterator end() const;  // Only defined for array type
     bool exists(const std::string& key) const { size_t i; return findKey(key, i); }
 
     bool isNull() const { return (typ == VNULL); }

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -216,6 +216,38 @@ const UniValue& UniValue::operator[](size_t index) const
     return values.at(index);
 }
 
+std::vector<UniValue>::iterator UniValue::begin()
+{
+    if (typ != VARR)
+        throw std::runtime_error("begin() not defined for non-array types");
+
+    return values.begin();
+}
+
+std::vector<UniValue>::iterator UniValue::end()
+{
+    if (typ != VARR)
+        throw std::runtime_error("end() not defined for non-array types");
+
+    return values.end();
+}
+
+std::vector<UniValue>::const_iterator UniValue::begin() const
+{
+    if (typ != VARR)
+        throw std::runtime_error("begin() not defined for non-array types");
+
+    return values.begin();
+}
+
+std::vector<UniValue>::const_iterator UniValue::end() const
+{
+    if (typ != VARR)
+        throw std::runtime_error("end() not defined for non-array types");
+
+    return values.end();
+}
+
 const char *uvTypeName(UniValue::VType t)
 {
     switch (t) {

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -236,6 +236,21 @@ BOOST_AUTO_TEST_CASE(univalue_array)
     BOOST_CHECK_EQUAL(arr[9].getValStr(), "1");
     BOOST_CHECK_EQUAL(arr[9].getType(), UniValue::VBOOL);
 
+    // Test that range-based for loops work as expected
+    int i{0};
+    for (auto& element : arr) {
+        BOOST_CHECK_EQUAL(element.getValStr(), arr[i].getValStr());
+        ++i;
+    }
+
+    // Test that range-based for loops work for const arrays
+    const auto carr = arr;
+    i = 0;
+    for (const auto& element : carr) {
+        BOOST_CHECK_EQUAL(element.getValStr(), carr[i].getValStr());
+        ++i;
+    }
+
     BOOST_CHECK_EQUAL(arr[999].getValStr(), "");
 
     arr.clear();


### PR DESCRIPTION
This allows c++11 range based for loops to be used with array type
UniValue objects.